### PR TITLE
Fix patch to handle updated QEMU as of 2dc7bf63cf77d23b287c8d78628d62…

### DIFF
--- a/qemu_patches.patch
+++ b/qemu_patches.patch
@@ -1619,7 +1619,7 @@ index 4d8f48e8c7..0eff99a80d 100644
 @@ -155,6 +155,13 @@ typedef struct CPUArchState {
  
      /* Fields from here on are preserved across CPU reset. */
-     uint32_t features;
+     uint64_t features;
 +
 +#ifdef CONFIG_CANNOLI
 +    /* Storage for Cannoli's internal register state */


### PR DESCRIPTION
Qemu commit [2dc7bf63cf77d23b287c8d78628d62046fba1bf4](https://github.com/qemu/qemu/commit/2dc7bf63cf77d23b287c8d78628d62046fba1bf4) increased the size of the features field in the m68k cpu struct, which broke patch application of `qemu_patches.patch` to latest QEMU. This fixes it up so qemu patches can be applied to latest git qemu as written in the README as of QEMU commit `dbc4f48b5a`.